### PR TITLE
qemu: add -nographic command line argument

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -32,22 +32,22 @@ CFLAGS += -Wall -O0
 run: $(TARGETS)
 	$(foreach bin,$^, \
 		$(if $(findstring armeb,$(bin)), \
-			echo $(bin); $(S2E_QEMU_BE) -M configurable -m 4M -kernel $(bin).json $(EXTRA);, \
-			echo $(bin); $(S2E_QEMU_LE) -M integratorcp -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin) $(EXTRA);))
+			echo $(bin); $(S2E_QEMU_BE) -monitor /dev/null -nographic -M configurable -m 4M -kernel $(bin).json $(EXTRA);, \
+			echo $(bin); $(S2E_QEMU_LE) -monitor /dev/null -nographic -M integratorcp -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin) $(EXTRA);))
 	@echo -e '\n--> Run `make logclean` to remove all output dirs \n'
 
 debug: $(TARGETS)
 	$(foreach bin,$^, \
 		$(if $(findstring armeb,$(bin)), \
-			echo $(bin); gdb --args $(S2E_QEMU_BE) -M configurable -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin).json $(EXTRA);, \
-			echo $(bin); gdb --args $(S2E_QEMU_LE) -M integratorcp -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin) $(EXTRA);))
+			echo $(bin); gdb --args $(S2E_QEMU_BE) -monitor /dev/null -nographic -M configurable -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin).json $(EXTRA);, \
+			echo $(bin); gdb --args $(S2E_QEMU_LE) -monitor /dev/null -nographic -M integratorcp -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin) $(EXTRA);))
 	@echo -e '\n--> Run `make logclean` to remove all output dirs \n'
 
 rdebug: $(TARGETS)
 	$(foreach bin,$^, \
 		$(if $(findstring armeb,$(bin)), \
-			echo $(bin); gdbserver localhost:10000 $(S2E_QEMU_BE) -M configurable -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin).json $(EXTRA);, \
-			echo $(bin); gdbserver localhost:10000 $(S2E_QEMU_LE) -M integratorcp -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin) $(EXTRA);))
+			echo $(bin); gdbserver localhost:10000 $(S2E_QEMU_BE) -monitor /dev/null  -nographic -M configurable -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin).json $(EXTRA);, \
+			echo $(bin); gdbserver localhost:10000 $(S2E_QEMU_LE) -monitor /dev/null -nographic -M integratorcp -m 4M -s2e-config-file $(bin)-config.lua -s2e-verbose -kernel $(bin) $(EXTRA);))
 	@echo -e '\n--> Run `make logclean` to remove all output dirs \n'
 
 .PHONY: clean

--- a/features/step_definitions/s2e.rb
+++ b/features/step_definitions/s2e.rb
@@ -18,14 +18,14 @@ Given(/^ARM firmware named "(.*?)"$/) do |fw|
 end
 
 When /^S2E test is run$/ do
-    @cmd = @s2e_cmd + " -M integratorcp -cpu cortex-a8 -m 4M -s2e-config-file " + @luacfg + " -s2e-verbose -kernel " + @bin
+    @cmd = @s2e_cmd + " -monitor /dev/null -nographic -M integratorcp -cpu cortex-a8 -m 4M -s2e-config-file " + @luacfg + " -s2e-verbose -kernel " + @bin
     run(unescape(@cmd), 30)
 end
 
 When(/^S2E test is run for architecture "(.*?)"$/) do |arch|
     @s2e_dir = File.dirname(File.dirname(@s2e_cmd))
     @s2e_arch_cmd = File.join(@s2e_dir, arch + "-s2e-softmmu", "qemu-system-" + arch)
-    @cmd = @s2e_arch_cmd + " -M integratorcp -cpu cortex-a8 -m 4M -s2e-config-file " + @luacfg + " -s2e-verbose -kernel " + @bin
+    @cmd = @s2e_arch_cmd + " -monitor /dev/null -nographic -M integratorcp -cpu cortex-a8 -m 4M -s2e-config-file " + @luacfg + " -s2e-verbose -kernel " + @bin
     run(unescape(@cmd), 30)
 end
 


### PR DESCRIPTION
Each time qemu starts a new (graphic) window is created. This is annoying. I'm not sure how this interacts with a test that uses stdout -- the monitor is printed to sdout. An extra fix might be adding '-monitor /dev/null'.
